### PR TITLE
Fix argument typo

### DIFF
--- a/src/commands/ignite/create.rs
+++ b/src/commands/ignite/create.rs
@@ -26,7 +26,7 @@ pub struct DeploymentConfig {
     #[clap(
         short = 's',
         long = "strategy",
-        help = "Scaling strategy, defaults to `autoscaled`"
+        help = "Scaling strategy, defaults to `autoscale`"
     )]
     pub scaling_strategy: Option<ScalingStrategy>,
 


### PR DESCRIPTION
Fixed typo for the autoscaling argument,
"autoscaled" isn't the valid argument, "autoscale" is